### PR TITLE
FIX : 테스트 케이스 오류 수정 #77, #72, #71

### DIFF
--- a/src/main/java/com/justdo/fruitfruit/controller/ProductController.java
+++ b/src/main/java/com/justdo/fruitfruit/controller/ProductController.java
@@ -129,7 +129,7 @@ public class ProductController {
         if (productList != null && !productList.isEmpty()) {
             resultMessage.printAllProduct(productList);
         } else {
-            resultMessage.productFailureMessage("viewAll");
+            resultMessage.productFailureMessage("viewNone");
         }
     }
 
@@ -141,8 +141,8 @@ public class ProductController {
 
         List<ProductDTO> productList = productService.selectAllProductByConsumer();
 
-        if (productList == null && productList.isEmpty()) {
-            userResultMessage.printAllProductResult("printError");
+        if (productList == null || productList.isEmpty()) {
+            userResultMessage.printAllProductResult("printNone");
         } else {
             userResultMessage.printAllProductResult("printSuccess");
             userResultMessage.printAllProductByUser(productList);
@@ -156,8 +156,8 @@ public class ProductController {
     public void selectAllProductByCategory(int categoryNum) {
         List<ProductDTO> productList = productService.selectAllProductByCategory(categoryNum);
 
-        if (productList == null && productList.isEmpty()) {
-            userResultMessage.printAllByCategoryResult("printError");
+        if (productList == null || productList.isEmpty()) {
+            userResultMessage.printAllByCategoryResult("printNone");
         } else {
             userResultMessage.printAllByCategoryResult("printSuccess");
             userResultMessage.printAllProductByUser(productList);

--- a/src/main/java/com/justdo/fruitfruit/controller/WarehouseController.java
+++ b/src/main/java/com/justdo/fruitfruit/controller/WarehouseController.java
@@ -27,7 +27,7 @@ public class WarehouseController {
      * */
     public void addRequestStockList(List<ProductDTO> productDTOS) {
         if(productDTOS == null || productDTOS.isEmpty()){
-            resultMessage.errorMessage("addRequestStock");
+            return;
         }
 
         boolean result = wareHouseService.addRequestStockList(productDTOS);
@@ -92,7 +92,7 @@ public class WarehouseController {
 
     public void addRequestReleaseList(List<RequestReleaseDTO> productDTOS) {
         if(productDTOS == null || productDTOS.isEmpty()){
-            resultMessage.errorMessage("addRequestRelease");
+            return;
         }
 
         boolean result = wareHouseService.addRequestReleaseList(productDTOS);

--- a/src/main/java/com/justdo/fruitfruit/model/dao/WarehouseMapper.java
+++ b/src/main/java/com/justdo/fruitfruit/model/dao/WarehouseMapper.java
@@ -36,4 +36,6 @@ public interface WarehouseMapper {
     int insertReleaseProductDate(List<RequestReleaseDTO> productDTOS);
 
     int updateMinusSectorData(List<RequestReleaseDTO> productDTOS);
+
+    int updateOrderStatus(List<RequestReleaseDTO> productDTOS);
 }

--- a/src/main/java/com/justdo/fruitfruit/model/dto/RequestReleaseDTO.java
+++ b/src/main/java/com/justdo/fruitfruit/model/dto/RequestReleaseDTO.java
@@ -16,4 +16,5 @@ public class RequestReleaseDTO {
     private String categoryName;
     private int quantity;
     private int productStatus;
+    private int orderSeq;
 }

--- a/src/main/java/com/justdo/fruitfruit/model/service/SellerService.java
+++ b/src/main/java/com/justdo/fruitfruit/model/service/SellerService.java
@@ -53,7 +53,6 @@ public class SellerService {
 
         try{
             int result = notificationMapper.modifyNotification(criteria);
-            System.out.println("알림을 확인 했습니다."); // 확인용 마지막 제출땐 삭제
             sqlSession.commit();
         }catch (Exception e){
             System.out.println("알림 확인 실패");

--- a/src/main/java/com/justdo/fruitfruit/model/service/UserService.java
+++ b/src/main/java/com/justdo/fruitfruit/model/service/UserService.java
@@ -249,7 +249,7 @@ public class UserService {
                 }
             }
         }else{
-            System.out.println("결재할 상품이 없습니다.");
+            System.out.println("결제할 상품이 없습니다.");
         }
 
 

--- a/src/main/java/com/justdo/fruitfruit/model/service/WarehouseService.java
+++ b/src/main/java/com/justdo/fruitfruit/model/service/WarehouseService.java
@@ -144,7 +144,8 @@ public class WarehouseService {
         int result = warehouseMapper.updateProductAmount(productDTOS);
         int insertResult = warehouseMapper.insertReleaseProductDate(productDTOS);
         int updateSectorResult = warehouseMapper.updateMinusSectorData(productDTOS);
-        if(result > 0 && insertResult>0 && updateSectorResult>0){
+        int updateOrdersResult = warehouseMapper.updateOrderStatus(productDTOS);
+        if(result > 0 && insertResult>0 && updateSectorResult>0 && updateOrdersResult>0){
             sqlSession.commit();;
         }else {
             sqlSession.rollback();

--- a/src/main/java/com/justdo/fruitfruit/view/ProductResultMessage.java
+++ b/src/main/java/com/justdo/fruitfruit/view/ProductResultMessage.java
@@ -39,6 +39,9 @@ public class ProductResultMessage {
             case "delete":
                 failureMessage = "상품 삭제를 실패하였습니다.";
                 break;
+            case "viewNone":
+                failureMessage = "조회할 상품정보가 없습니다.";
+                break;
         }
         System.out.println(failureMessage);
     }

--- a/src/main/java/com/justdo/fruitfruit/view/SellerMenu.java
+++ b/src/main/java/com/justdo/fruitfruit/view/SellerMenu.java
@@ -209,7 +209,7 @@ public class SellerMenu {
                     청 구 영 수 증
                     =====================
                     """);
-            sellerService.selectAllBillingAmount(this.id);
+            sellerService.selectAllBillingAmount(userDTO.getId());
             return;
         }
     /***
@@ -221,8 +221,8 @@ public class SellerMenu {
                 알 림 목 록
                 =====================
                 """);
-        sellerService.selectAllNotification(this.id);
-        sellerService.updateNotification(this.id);
+        sellerService.selectAllNotification(userDTO.getId());
+        sellerService.updateNotification(userDTO.getId());
         return;
     }
 }

--- a/src/main/java/com/justdo/fruitfruit/view/UserMenu.java
+++ b/src/main/java/com/justdo/fruitfruit/view/UserMenu.java
@@ -257,7 +257,7 @@ public class UserMenu {
      * @return boolean 결과값 모두 일치하면 true 반환
      * */
     public boolean isValidPassword(String password) {
-        String regex = "^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[@#$%^&+=])(?=\\S+$).{7,}$";
+        String regex = "^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[!@#$%^&+=])(?=\\S+$).{7,}$";
         return password.matches(regex);
     }
 

--- a/src/main/java/com/justdo/fruitfruit/view/UserResultMessage.java
+++ b/src/main/java/com/justdo/fruitfruit/view/UserResultMessage.java
@@ -67,6 +67,9 @@ public class UserResultMessage {
             case "printError" :
                 status = "전체조회에 실패하였습니다.";
                 break;
+            case "printNone" :
+                status = "조회할 상품목록이 없습니다.";
+                break;
         }
         System.out.println(status);
     }
@@ -80,6 +83,9 @@ public class UserResultMessage {
                 break;
             case "printError" :
                 status = "카테고리별 물품 실패하였습니다.";
+                break;
+            case "printNone" :
+                status = "조회할 상품목록이 없습니다.";
                 break;
         }
         System.out.println(status);

--- a/src/main/java/com/justdo/fruitfruit/view/WarehouseMenu.java
+++ b/src/main/java/com/justdo/fruitfruit/view/WarehouseMenu.java
@@ -30,7 +30,7 @@ public class WarehouseMenu {
                     1. 입고요청
                     2. 출고요청
                     3. 창고 재고 확인
-                    4. 재고 이동
+                    4. 재고 이동 이력 조회
                     9. 이전으로
                     ==========================""");
             int menu = inputReader.selectMenuNum();
@@ -60,7 +60,7 @@ public class WarehouseMenu {
         do {
             System.out.println("""
                     ==========================
-                    재 고 이 동
+                    재 고 이 동 이 력 조 회
                     ==========================
                     1. 전체 조회
                     2. 입고 조회

--- a/src/main/java/com/justdo/fruitfruit/view/WarehouseResultMessage.java
+++ b/src/main/java/com/justdo/fruitfruit/view/WarehouseResultMessage.java
@@ -13,17 +13,11 @@ public class WarehouseResultMessage {
     public void errorMessage(String errorCode) {
         String errorMsg = "";
         switch (errorCode) {
-            case "addRequestStock":
-                errorMsg="입고처리할 상품정보가 없습니다.";
-                break;
             case "addRequestStock2":
                 errorMsg = "입고처리에 실패하였습니다";
                 break;
             case "addNotificationInfo":
                 errorMsg = "알림 등록에 실패하였습니다.";
-                break;
-            case "addRequestRelease":
-                errorMsg="출고처리할 상품정보가 없습니다.";
                 break;
             case "addRequestRelease2":
                 errorMsg = "출고처리에 실패하였습니다";

--- a/src/main/resources/sql/seller/BillingMapper.xml
+++ b/src/main/resources/sql/seller/BillingMapper.xml
@@ -7,7 +7,7 @@
         <result property="userSeq" column="user_seq"/>
         <result property="companySeq" column="company_seq"/>
         <result property="totalPrice" column="total_price"/>
-        <result property="sta" column="status"/>
+        <result property="status" column="status"/>
         <result property="registerDate" column="register_date"/>
         <result property="updateDate" column="update_date"/>
     </resultMap>

--- a/src/main/resources/sql/seller/NotificationMapper.xml
+++ b/src/main/resources/sql/seller/NotificationMapper.xml
@@ -14,13 +14,13 @@
         <result property="id" column="id"/>
     </resultMap>
 
-    <select id="selectAllNotification" parameterType="String" resultType="com.justdo.fruitfruit.model.dto.NotificationDTO">
+    <select id="selectAllNotification" parameterType="hashmap" resultType="com.justdo.fruitfruit.model.dto.NotificationDTO">
         SELECT A.notification_type, A.notification_content
         FROM notification A
-        WHERE A.user_seq = (SELECT user_seq FROM user WHERE id = #{ userid } AND is_read = 1)
+        WHERE A.user_seq = (SELECT user_seq FROM user WHERE id = #{ userid } AND is_read = 0)
     </select>
     
-    <select id="modifyNotification" parameterType="String" resultType="com.justdo.fruitfruit.model.dto.NotificationDTO">
-        UPDATE notification SET is_read = 0 WHERE user_seq = (SELECT user_seq FROM user WHERE id = #{ userid } AND is_read = 1)
-    </select>
+    <update id="modifyNotification" parameterType="hashmap" >
+        UPDATE notification SET is_read = 1 WHERE user_seq = (SELECT user_seq FROM user WHERE id = #{ userid } AND is_read = 0)
+    </update>
 </mapper>

--- a/src/main/resources/sql/seller/ProductMapper.xml
+++ b/src/main/resources/sql/seller/ProductMapper.xml
@@ -41,6 +41,7 @@
         FROM product p
         JOIN category c ON p.category_seq = c.category_seq
         WHERE p.user_seq = #{ userSeq }
+        AND p.delete_yn = 0
         ORDER BY p.register_date
     </select>
 

--- a/src/main/resources/sql/system/SystemMapper.xml
+++ b/src/main/resources/sql/system/SystemMapper.xml
@@ -58,6 +58,7 @@
             U.auth = 4
           AND
             U.delete_yn = 'N'
+        AND C.delete_yn = 0
         ORDER BY
             U.user_seq
     </select>
@@ -96,9 +97,8 @@
         WHERE
             user_seq = #{ userSeq };
 
-        DELETE FROM
-            company
-
+        update company
+        set delete_yn=1
         WHERE
             user_seq = #{ userSeq };
     </update>
@@ -114,6 +114,7 @@
             U.auth = 3
               AND
             U.delete_yn = 'N'
+        AND C.delete_yn = 0
         ORDER BY
             U.user_seq
     </select>
@@ -149,12 +150,13 @@
             product_seq
     </select>
 
-    <delete id="deleteProductInfo">
-        DELETE FROM
-            product
+    <update id="deleteProductInfo">
+        update product
+        set
+        delete_yn = true
         WHERE
             product_seq = #{ product_seq }
-    </delete>
+    </update>
 
     <!-- 주문 관리 메뉴 -->
 
@@ -195,6 +197,7 @@
             O.status = '4'
         AND
             EXTRACT(MONTH FROM O.register_date) = #{ month }
+        AND C.delete_yn = 0
         GROUP BY
             C.company_seq, C.company_name
         ORDER BY
@@ -214,6 +217,7 @@
             O.status = '4'
               AND
             EXTRACT(YEAR FROM O.register_date) = #{ year }
+        AND C.delete_yn = 0
         GROUP BY
             C.company_seq, C.company_name
         ORDER BY

--- a/src/main/resources/sql/user/ProductMapper.xml
+++ b/src/main/resources/sql/user/ProductMapper.xml
@@ -18,7 +18,8 @@
         ON P.category_seq = C.category_seq
         LEFT JOIN grade G
         ON P.grade_seq = G.grade_seq
-        WHERE P.product_status = 2;
+        WHERE P.product_status = 2
+        and P.delete_yn = 0
     </select>
 
     <select id="selectAllProductByCategory" resultType="productDTO">
@@ -37,7 +38,8 @@
         ON P.grade_seq = G.grade_seq
         WHERE
             P.category_seq = #{categorySeq}
-            AND P.product_status = 2;
+            AND P.product_status = 2
+            and P.delete_yn = 0
     </select>
 
     <select id="selectAllCategory" resultType="categoryDTO">
@@ -49,10 +51,14 @@
     </select>
 
     <select id="productName" resultType="String" parameterType="int">
-            select product_name from product where product_seq = #{ productSeq }
+            select product_name from product where product_seq = #{ productSeq } and delete_yn = 0
     </select>
     <select id="productPrice" parameterType="_int" resultType="_int">
-        select A.product_price from product A where A.product_seq = (select B.product_seq from cart B where B.product_seq = #{ productSeq } and B.user_seq = #{ userSeq } and delete_yn = 0 )
+        select
+            A.product_price
+        from product A
+        where A.product_seq = (select B.product_seq from cart B where B.product_seq = #{ productSeq } and B.user_seq = #{ userSeq } and B.delete_yn = 0 )
+        and A.delete_yn = 0
     </select>
 
 </mapper>

--- a/src/main/resources/sql/warehouse/WarehouseMapper.xml
+++ b/src/main/resources/sql/warehouse/WarehouseMapper.xml
@@ -24,6 +24,7 @@
             inner join category c on p.category_seq = c.category_seq
         WHERE
             p.product_status = #{status}
+            and p.delete_yn = 0
     </select>
 
     <select id="findByCategorySeq" parameterType="int" resultType="gradeDTO">
@@ -61,7 +62,7 @@
                 sector_seq = #{item.sectorSeq},
                 grade_seq = #{item.gradeSeq},
                 product_status = #{item.productStatus},
-                update_date = now(),
+                update_date = now(),1
                 expiration_date=date_add(now(),INTERVAL 14 DAY)
             WHERE
                 product_seq = #{item.productSeq}
@@ -116,6 +117,7 @@
             inner join user u on p.user_seq = u.user_seq
         WHERE
             p.product_status = #{productStatus}
+            AND p.delete_yn = 0
             <if test="userSeq != 0">
                 AND p.user_seq = #{userSeq}
             </if>
@@ -161,6 +163,7 @@
         inner join user u on p.user_seq = u.user_seq
         WHERE
             p.product_status = 2
+            AND p.delete_yn = 0
             <![CDATA[
                 AND (
                 p.product_amount <= 5
@@ -196,7 +199,7 @@
             LEFT JOIN sector s ON p.sector_seq = s.sector_seq
             LEFT JOIN category c ON p.category_seq = c.category_seq
         where
-            1=1
+            p.delete_yn = 0
             <if test="status != 0">
                 AND pl.status = #{status}
             </if>
@@ -211,14 +214,15 @@
             p.sector_seq,
             p.product_name,
             cate.category_name,
-            c.quantity
+            c.quantity,
+            o.order_seq
         FROM
         cart c
         INNER JOIN orders o on c.order_seq = o.order_seq
         INNER JOIN product p ON c.product_seq = p.product_seq
         INNER JOIN category cate ON cate.category_seq = p.category_seq
         WHERE
-        p.status = #{status}
+        o.status = #{status}
         and c.delete_yn = 1
     </select>
 
@@ -228,7 +232,7 @@
             product
             SET
             product_amount = product_amount - #{item.quantity},
-            product_status = #{item.productStatus}
+            update_date = now()
             WHERE
             product_seq = #{item.productSeq}
         </foreach>
@@ -256,6 +260,17 @@
             volume = volume + #{item.quantity}
             WHERE
             sector_seq = #{item.sectorSeq}
+        </foreach>
+    </update>
+
+    <update id="updateOrderStatus" parameterType="requestReleaseDTO">
+        <foreach collection="list" item="item" separator=";">
+            update orders
+            set
+            status = #{item.productStatus},
+            update_date = now()
+            where
+            order_seq = #{item.orderSeq}
         </foreach>
     </update>
 </mapper>


### PR DESCRIPTION
1. 비밀번호 정규식 "!" 추가
2. 입고시 입고요청없는 상태로  입고 실행시 오류발생 -> 리스트가 null인경우 메세지 표출하도록 수정
3. 출고시 출고요청없는데 출고실행시 오류발생 -> 리스트가 null인경우 메세지 표출하도록 수정
4. 상품삭제 시 오류발생 -> product테이블에 delete_yn업데이트로 변경 -> 모든 상품정보에 delete_yn 조건 추가
5. (비회원,구매자)상품목록 표시 -> 없을경우 조회성공메세지는 나오지만 조회내용 표시안됨 -> null이고 empty일때 에러코드  -> 조건 or 로 수정, 메세지 case 추가해서 조회내용없음으로 메세지 출력되도록 변경
6. (판매자 메뉴 -> 1. 판매 물품 관리 -> 1. 조회) 없을 경우 상품 조회 실패했다고 나옴 -> 메세지 case 추가해서 조회내용없음으로 메세지 출력되도록 변경
7. 판매자 청구금 조회, 알림조회 실행안되고 실패 메세지 표시 -> this.id -> userDTO.getId()
알림 조회  -> is_read변경 SQL의 마이바티스 xml 태그가 잘못 작성되어 수정 (select ->update)

알림조회 null 오류원인
```
<select id="modifyNotification" parameterType="hashmap" resultType="com.justdo.fruitfruit.model.dto.NotificationDTO">
        UPDATE notification SET is_read = 1 WHERE user_seq = (SELECT user_seq FROM user WHERE id = #{ userid } AND is_read = 0)
    </select>
update인데 select태그
```
8. 판매자 삭제 오류 -> deleteSellerInfo의 company테이블이 카트테이블과 제약조건으로 묶여 있어서 안됨 -> delete_Yn추가  